### PR TITLE
chore: remove slack notification

### DIFF
--- a/.github/workflows/analyze.job.yaml
+++ b/.github/workflows/analyze.job.yaml
@@ -39,13 +39,3 @@ jobs:
 
       - name: Remove matcher
         run: echo "::remove-matcher owner=dart-analyzer::"
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: always()
-        env:
-          SLACK_CHANNEL: github-actions
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
-          SLACK_TITLE: Job
-          SLACK_MESSAGE: ${{ github.job }}

--- a/.github/workflows/danger.job.yaml
+++ b/.github/workflows/danger.job.yaml
@@ -50,13 +50,3 @@ jobs:
           danger_id: 'danger-pr'
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: always()
-        env:
-          SLACK_CHANNEL: github-actions
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
-          SLACK_TITLE: Job
-          SLACK_MESSAGE: ${{ github.job }}

--- a/.github/workflows/test.job.yaml
+++ b/.github/workflows/test.job.yaml
@@ -33,13 +33,3 @@ jobs:
 
       - name: Run flutter test
         run: flutter test
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: always()
-        env:
-          SLACK_CHANNEL: github-actions
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
-          SLACK_TITLE: Job
-          SLACK_MESSAGE: ${{ github.job }}


### PR DESCRIPTION
Because PRs created by dependabot can't access to secret.