### PR TITLE
ci: Add Japanese language support to PR reviewer

### DIFF
--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -25,3 +25,4 @@ jobs:
           debug: false
           review_simple_changes: true
           review_comment_lgtm: true
+          language: ja-JP


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能：GitHubのPRレビュアーワークフローに日本語サポートを追加しました。これにより、ユーザーは`language`パラメータを`ja-JP`に設定することで、プルリクエストのレビューを日本語で受け取ることが可能になります。この変更はエンドユーザーに直接影響を与え、コードレベルの詳細は含まれていません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->