### PR TITLE
refactor: Remove unused isFirstRun logic

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:buzz_recipe_viewer/app.dart';
 import 'package:buzz_recipe_viewer/model/isar/favorite.dart';
 import 'package:buzz_recipe_viewer/model/isar/history.dart';
 import 'package:buzz_recipe_viewer/model/isar/recipe_note.dart';
-import 'package:buzz_recipe_viewer/provider/is_first_run_provider.dart';
 import 'package:buzz_recipe_viewer/provider/isar_provider.dart';
 import 'package:buzz_recipe_viewer/provider/package_info_provider.dart';
 import 'package:buzz_recipe_viewer/provider/shared_preferences_provider.dart';
@@ -31,14 +30,10 @@ void main() async {
     SharedPreferences.getInstance()
   ).wait;
 
-  // 初回起動かどうか（未使用）
-  final isFirstRun = await isar.getSize() == 0;
-
   runApp(
     ProviderScope(
       overrides: [
         isarProvider.overrideWithValue(isar),
-        isFirstRunProvider.overrideWithValue(isFirstRun),
         packageInfoProvider.overrideWithValue(packageInfo),
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
       ],

--- a/lib/provider/is_first_run_provider.dart
+++ b/lib/provider/is_first_run_provider.dart
@@ -1,3 +1,0 @@
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-
-final isFirstRunProvider = Provider<bool>((_) => throw UnimplementedError());


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Removed unused `isFirstRun` logic from the application. This change simplifies the codebase and improves maintainability by eliminating unnecessary dependencies and variables. The removal of this logic does not affect the user-facing functionality or behavior of the application.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->